### PR TITLE
fix: correct RGB macro precedence bug, stale comments, and unused enum entries

### DIFF
--- a/keyboards/boardsource/lulu/avr/keymaps/perrwa/config.h
+++ b/keyboards/boardsource/lulu/avr/keymaps/perrwa/config.h
@@ -38,9 +38,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     #define RGB_MATRIX_TIMEOUT 300000 // turn off effects after 5 minutes
     #define RGB_MATRIX_SLEEP // turn off effects when suspended
     // #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
-    #define RGB_MATRIX_LED_PROCESS_LIMIT (RGB_MATRIX_LED_COUNT + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
+    #define RGB_MATRIX_LED_PROCESS_LIMIT ((RGB_MATRIX_LED_COUNT + 4) / 5) // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
     #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
-    #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 80 // limits maximum brightness of LEDs to 150 out of 255. Higher may cause the controller to crash.
+    #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 80 // limits maximum brightness of LEDs to 80 out of 255. Higher may cause the controller to crash.
     #define RGB_MATRIX_HUE_STEP 8
     #define RGB_MATRIX_SAT_STEP 8
     #define RGB_MATRIX_VAL_STEP 8

--- a/keyboards/crkbd/rev1/keymaps/perrwa/config.h
+++ b/keyboards/crkbd/rev1/keymaps/perrwa/config.h
@@ -36,9 +36,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     #define RGB_MATRIX_TIMEOUT 300000 // turn off effects after 5 minutes
     #define RGB_MATRIX_SLEEP // turn off effects when suspended
     // #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
-    #define RGB_MATRIX_LED_PROCESS_LIMIT (RGB_MATRIX_LED_COUNT + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
+    #define RGB_MATRIX_LED_PROCESS_LIMIT ((RGB_MATRIX_LED_COUNT + 4) / 5) // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
     #define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
-    #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 120 // limits maximum brightness of LEDs to 150 out of 255. Higher may cause the controller to crash.
+    #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 120 // limits maximum brightness of LEDs to 120 out of 255. Higher may cause the controller to crash.
     #define RGB_MATRIX_HUE_STEP 8
     #define RGB_MATRIX_SAT_STEP 8
     #define RGB_MATRIX_VAL_STEP 8

--- a/keyboards/crkbd/rev1/keymaps/perrwa/keymap.c
+++ b/keyboards/crkbd/rev1/keymaps/perrwa/keymap.c
@@ -32,15 +32,6 @@ enum crkbd_layers {
 
 enum custom_keycodes {
     _RGBRST = SAFE_RANGE,
-
-    _SGLBRC,
-    _SGRBRC,
-    _GUIENT,
-
-    _LWRSPC,
-    _NAVESC,
-    _MO_NUM,
-    _MO_LWR,
 };
 
 // Custom keycodes for keymap shorthand


### PR DESCRIPTION
## Summary

Fixes three issues found during code review of QMK keyboard configurations.

## Changes

### Bug fix: `RGB_MATRIX_LED_PROCESS_LIMIT` operator precedence (High)

The macro `(RGB_MATRIX_LED_COUNT + 4) / 5` was missing outer parentheses, causing C operator precedence to evaluate it as `RGB_MATRIX_LED_COUNT + (4 / 5)` → effectively just `RGB_MATRIX_LED_COUNT`. This defeated the purpose of limiting LED processing to one-fifth of the total count. Fixed in both crkbd and lulu configs.

### Fix: Stale brightness comments (Medium)

`RGB_MATRIX_MAXIMUM_BRIGHTNESS` comments incorrectly stated "150 out of 255" when the actual values are 120 (crkbd) and 80 (lulu). Updated comments to match.

### Refactor: Remove unused `custom_keycodes` enum entries (Medium)

The crkbd `keymap.c` enum included entries (`_SGLBRC`, `_SGRBRC`, `_GUIENT`, `_LWRSPC`, `_NAVESC`, `_MO_NUM`, `_MO_LWR`) that were immediately redefined as preprocessor macros and never handled in `process_record_user()`. Only `_RGBRST` is an actual custom keycode. Removed the unused entries to avoid wasting SAFE_RANGE keycode space.

## Files Changed

- `keyboards/crkbd/rev1/keymaps/perrwa/config.h`
- `keyboards/boardsource/lulu/avr/keymaps/perrwa/config.h`
- `keyboards/crkbd/rev1/keymaps/perrwa/keymap.c`
