### PR TITLE
feat: add auto-generated README for keymap-drawer SVGs

### DIFF
--- a/.github/workflows/draw.yml
+++ b/.github/workflows/draw.yml
@@ -31,8 +31,25 @@ jobs:
               -o "${yaml%.yaml}.svg"
           done
 
+      - name: Generate keymap-drawer README
+        run: |
+          cd keymap-drawer
+          shopt -s nullglob
+          {
+            echo "# Keymap Visualizations"
+            echo ""
+            echo "Auto-generated from keymap YAML definitions via [keymap-drawer](https://github.com/caksoylar/keymap-drawer)."
+            for svg in *.svg; do
+              name="${svg%.svg}"
+              echo ""
+              echo "## ${name}"
+              echo ""
+              echo "![${name}](${svg})"
+            done
+          } > README.md
+
       - name: Commit updated images
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          file_pattern: 'keymap-drawer/*.svg'
+          file_pattern: 'keymap-drawer/*.svg keymap-drawer/README.md'
           commit_message: "chore: update keymap-drawer visualizations"

--- a/keymap-drawer/README.md
+++ b/keymap-drawer/README.md
@@ -1,0 +1,15 @@
+# Keymap Visualizations
+
+Auto-generated from keymap YAML definitions via [keymap-drawer](https://github.com/caksoylar/keymap-drawer).
+
+## crkbd
+
+![crkbd](crkbd.svg)
+
+## lulu
+
+![lulu](lulu.svg)
+
+## portico
+
+![portico](portico.svg)


### PR DESCRIPTION
## Summary

Adds a `README.md` to `keymap-drawer/` that displays all SVG keymap visualizations inline, and updates the `draw.yml` workflow to auto-regenerate the README whenever SVGs are redrawn.

## Changes

- **`keymap-drawer/README.md`** — New file listing all SVG visualizations (crkbd, lulu, portico)
- **`.github/workflows/draw.yml`** — Added "Generate keymap-drawer README" step that loops over `*.svg` and rebuilds the README before committing; uses `nullglob` to handle the empty-directory edge case; updated commit file pattern to include `README.md`

## Testing

- Verified the generated README matches CI script output
- `nullglob` guard ensures no broken entries if SVGs are absent
