### PR TITLE
fix: qualify .held CSS selector in keymap-drawer config

### DIFF
--- a/keymap-drawer/crkbd.svg
+++ b/keymap-drawer/crkbd.svg
@@ -234,7 +234,7 @@ path.combo {
 .shifted    { fill: #00CED1; }
 .right      { fill: #9370DB; }
 .left       { fill: #FFD700; }
-.held       { fill: #ddffdd; }
+rect.held, rect.combo.held { fill: #ddffdd; }
 rect.toggle { fill: #ffeedd; }
 [class~="material:joystick"] { fill: #2E8B57 !important; }
 /* Per-layer tap colors — crkbd */

--- a/keymap-drawer/lulu.svg
+++ b/keymap-drawer/lulu.svg
@@ -192,7 +192,7 @@ path.combo {
 .shifted    { fill: #00CED1; }
 .right      { fill: #9370DB; }
 .left       { fill: #FFD700; }
-.held       { fill: #ddffdd; }
+rect.held, rect.combo.held { fill: #ddffdd; }
 rect.toggle { fill: #ffeedd; }
 [class~="material:joystick"] { fill: #2E8B57 !important; }
 /* Per-layer tap colors — crkbd */

--- a/keymap-drawer/portico.svg
+++ b/keymap-drawer/portico.svg
@@ -222,7 +222,7 @@ path.combo {
 .shifted    { fill: #00CED1; }
 .right      { fill: #9370DB; }
 .left       { fill: #FFD700; }
-.held       { fill: #ddffdd; }
+rect.held, rect.combo.held { fill: #ddffdd; }
 rect.toggle { fill: #ffeedd; }
 [class~="material:joystick"] { fill: #2E8B57 !important; }
 /* Per-layer tap colors — crkbd */

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -23,7 +23,7 @@ draw_config:
     .shifted    { fill: #00CED1; }
     .right      { fill: #9370DB; }
     .left       { fill: #FFD700; }
-    .held       { fill: #ddffdd; }
+    rect.held, rect.combo.held { fill: #ddffdd; }
     rect.toggle { fill: #ffeedd; }
     [class~="material:joystick"] { fill: #2E8B57 !important; }
     /* Per-layer tap colors — crkbd */


### PR DESCRIPTION
Qualifies the `.held` CSS selector in keymap-drawer config so the fill rule only targets key and combo rectangles (`rect.held, rect.combo.held`) instead of any element with class `held`.

Prevents unintended style bleed if keymap-drawer ever adds other SVG elements with that class.
