### PR TITLE
ci: pin qmk_cli and keymap-drawer versions

### DIFF
--- a/.github/workflows/draw.yml
+++ b/.github/workflows/draw.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   draw:
     runs-on: ubuntu-latest
-    container: ghcr.io/qmk/qmk_cli:latest
+    container: ghcr.io/qmk/qmk_cli:1.2.0
     timeout-minutes: 15
     permissions:
       contents: write
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r qmk_firmware/requirements.txt
-          pip install keymap-drawer
+          pip install keymap-drawer==0.23.0
 
       - name: Configure QMK CLI
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Junk files
 *.bak
 *.swp
+*.zip
+
 *~
 .DS_Store
 ._*


### PR DESCRIPTION
Pin two floating versions in the `draw.yml` workflow for reproducible CI:

- `ghcr.io/qmk/qmk_cli:latest` → `:1.2.0`
- `pip install keymap-drawer` → `keymap-drawer==0.23.0`

Also adds `*.zip` to `.gitignore`.
